### PR TITLE
Fix a bug that prevents module to load on case-sensitive filesystems

### DIFF
--- a/lib/response/index.js
+++ b/lib/response/index.js
@@ -3,7 +3,7 @@
 var response = exports; exports.constructor = function response(){};
 
 var _ = require('lodash');
-var TextResponse = require('./Text').TextResponse;
+var TextResponse = require('./text').TextResponse;
 
 var badDeveloper = 'CommandKindResponse not exposed';
 


### PR DESCRIPTION
Trying the module on Linux, which uses a case-sensitive filesystem, it failed to load. This change seems to fix the bug.